### PR TITLE
feat: support configurable destination SRS

### DIFF
--- a/src/cityjson/index.ts
+++ b/src/cityjson/index.ts
@@ -17,6 +17,7 @@ import {
 } from "./workerPayload.js";
 import { queue } from "async";
 import { WorkerPool } from "./workerPool.js";
+import { existsSync } from "fs";
 
 Logger.DEFAULT_INSTANCE = new Logger(Logger.Verbosity.SILENT);
 
@@ -58,6 +59,14 @@ export async function generateTileDatabaseFromCityJSON(
   } = {}
 ) {
   const { threadCount = 4 } = opts;
+
+  if (!existsSync(inputFolder)) {
+    throw new Error(`FATAL: no such directory: ${inputFolder}`);
+  }
+
+  if (!existsSync(outputFolder)) {
+    throw new Error(`FATAL: no such directory: ${outputFolder}`);
+  }
 
   const files = await glob("**/*.json", {
     absolute: true,

--- a/src/cityjson/index.ts
+++ b/src/cityjson/index.ts
@@ -21,13 +21,39 @@ import { WorkerPool } from "./workerPool.js";
 Logger.DEFAULT_INSTANCE = new Logger(Logger.Verbosity.SILENT);
 
 export async function generateTileDatabaseFromCityJSON(
+  /**
+   * The input folder containing the CityJSON files to aggregate.
+   */
   inputFolder: string,
+  /**
+   * The output folder. Must exist.
+   */
   outputFolder: string,
+  /**
+   * The CityJSON appearance to use.
+   */
   appearance: string,
+  /**
+   * The progress callback function.
+   * @param progress - The progress value in normalized form, where 0 = 0% and 1 = 100%.
+   */
   onProgress: (progress: number) => void,
   opts: {
+    /**
+     * The number of threads to use.
+     * @default 4
+     */
     threadCount?: number;
+    /**
+     * The spatial reference system of the input files expressed as a [PROJ definition](https://proj.org/en/stable/usage/quickstart.html).
+     * If unspecified, will attempt to read the spatial reference from each CityJSON file, if possible.
+     * @default null
+     */
     srcSRS?: string;
+    /**
+     * The destination spatial reference system expressed as a [PROJ definition](https://proj.org/en/stable/usage/quickstart.html).
+     * @default "+proj=geocent +datum=WGS84 +units=m +no_defs +type=crs"
+     */
     destSRS?: string;
   } = {}
 ) {

--- a/src/cityjson/index.ts
+++ b/src/cityjson/index.ts
@@ -28,6 +28,7 @@ export async function generateTileDatabaseFromCityJSON(
   opts: {
     threadCount?: number;
     srcSRS?: string;
+    destSRS?: string;
   } = {}
 ) {
   const { threadCount = 4 } = opts;
@@ -160,6 +161,7 @@ export async function generateTileDatabaseFromCityJSON(
             id,
             folderPath,
             appearance,
+            dest: opts.destSRS
           },
         });
 

--- a/src/cityjson/worker.ts
+++ b/src/cityjson/worker.ts
@@ -8,11 +8,12 @@ import { Database } from "sqlite";
 
 Logger.DEFAULT_INSTANCE = new Logger(Logger.Verbosity.SILENT);
 
+const DEFAULT_DEST_SRS = "+proj=geocent +datum=WGS84 +units=m +no_defs +type=crs";
+
 if (!parentPort) throw new Error("Is not being called in a worker context!");
 
 let cityJson: CityJSONV201;
 let src = "";
-const dest = "+proj=geocent +datum=WGS84 +units=m +no_defs +type=crs";
 let dbInstance: Database | null = null;
 
 parentPort.on("message", async (value: WorkerPayloads) => {
@@ -33,7 +34,7 @@ parentPort.on("message", async (value: WorkerPayloads) => {
             id: value.data.id,
             cityJson,
             src,
-            dest,
+            dest: value.data.dest ?? DEFAULT_DEST_SRS,
             folderPath: value.data.folderPath,
             appearance: value.data.appearance,
             noTransform: false,

--- a/src/cityjson/workerPayload.ts
+++ b/src/cityjson/workerPayload.ts
@@ -15,6 +15,7 @@ export type WorkerInitPayload = {
 export type WorkerWorkPayload = {
   type: "work";
   data: {
+    dest?: string;
     id: string;
     folderPath: string;
     appearance: string;


### PR DESCRIPTION
This PR makes it possible to generate tilesets in arbitrary coordinate systems, as long as the PROJ definition is passed to the `destSRS` optional property in the options of `generateTileDatabaseFromCityJSON()`:

```ts
  const { dbFilePath } = await generateTileDatabaseFromCityJSON(
    inputFolder: "./input",
    outputFolder: "./output",
    appearance: "FMETheme",
    console.log,
    {
      threadCount: 8,
      srcSRS: "+proj=lcc +lat_0=65 +lon_0=-19 +lat_1=64.25 +lat_2=65.75 +x_0=500000 +y_0=500000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs",
      destSRS: "+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs +type=crs"
    }
  );
```